### PR TITLE
Allow 0 length strings to be padded.

### DIFF
--- a/rightpad.js
+++ b/rightpad.js
@@ -5,9 +5,6 @@ exports = module.exports = function rightPad (_string, _length, _char) {
   if (typeof _string !== 'string') {
     throw new Error('The string parameter must be a string.');
   }
-  if (_string.length < 1) {
-    throw new Error('The string parameter must be 1 character or longer.');
-  }
   if (typeof _length !== 'number') {
     throw new Error('The length parameter must be a number.');
   }


### PR DESCRIPTION
Allow 0 length strings to be padded

e.g. 
```javascript
pad('', 5, 'a') // 'aaaaa'
```

- There is no reason not to.
- This is the behaviour of `left-pad`, while they are separate packages I think most people would expect them to have the same behaviour.
